### PR TITLE
README.md fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ go get -u github.com/sethvargo/go-diceware/diceware
 package main
 
 import (
+  "log"
   "strings"
 
   "github.com/sethvargo/go-diceware/diceware"


### PR DESCRIPTION
Example code fails without `import "log"`

```
➜  ~ go run example.go
./example.go:13:3: undefined: log
./example.go:15:2: undefined: log
```